### PR TITLE
fix fmha input bug

### DIFF
--- a/codegeex/oneflow/codegeex_model.py
+++ b/codegeex/oneflow/codegeex_model.py
@@ -144,11 +144,11 @@ class SelfAttention(torch.nn.Module):
         if hasattr(torch._C, 'fused_multi_head_attention_inference'):
             if layer_past is not None:
                 context_layer = torch._C.fused_multi_head_attention_inference(
-                        origin_query_layer.view(query_layer.size()[1], query_layer.size()[0], -1), origin_key_layer.view(key_layer.size()[1], key_layer.size()[0], -1), origin_value_layer.view(value_layer.size()[1], value_layer.size()[0], -1), self.num_attention_heads, causal=False
+                        origin_query_layer.view(query_layer.size()[0], query_layer.size()[1], -1).transpose(0, 1), origin_key_layer.view(key_layer.size()[0], key_layer.size()[1], -1).transpose(0, 1), origin_value_layer.view(value_layer.size()[0], value_layer.size()[1], -1).transpose(0, 1), self.num_attention_heads, causal=False
                 ).transpose(0, 1)
             else:
                 context_layer = torch._C.fused_multi_head_attention_inference(
-                        origin_query_layer.view(query_layer.size()[1], query_layer.size()[0], -1), origin_key_layer.view(key_layer.size()[1], key_layer.size()[0], -1), origin_value_layer.view(value_layer.size()[1], value_layer.size()[0], -1), self.num_attention_heads, causal=True
+                        origin_query_layer.view(query_layer.size()[0], query_layer.size()[1], -1).transpose(0, 1), origin_key_layer.view(key_layer.size()[0], key_layer.size()[1], -1).transpose(0, 1), origin_value_layer.view(value_layer.size()[0], value_layer.size()[1], -1).transpose(0, 1), self.num_attention_heads, causal=True
                 ).transpose(0, 1)
         else:
             # ===================================
@@ -335,11 +335,11 @@ class TopQuerySelfAttention(torch.nn.Module):
         if hasattr(torch._C, 'fused_multi_head_attention_inference'):
             if layer_past is not None:
                 context_layer = torch._C.fused_multi_head_attention_inference(
-                        origin_query_layer.view(query_layer.size()[1], query_layer.size()[0], -1), origin_key_layer.view(key_layer.size()[1], key_layer.size()[0], -1), origin_value_layer.view(value_layer.size()[1], value_layer.size()[0], -1), self.num_attention_heads, causal=False
+                        origin_query_layer.view(query_layer.size()[0], query_layer.size()[1], -1).transpose(0, 1), origin_key_layer.view(key_layer.size()[0], key_layer.size()[1], -1).transpose(0, 1), origin_value_layer.view(value_layer.size()[0], value_layer.size()[1], -1).transpose(0, 1), self.num_attention_heads, causal=False
                 ).transpose(0, 1)
             else:
                 context_layer = torch._C.fused_multi_head_attention_inference(
-                        origin_query_layer.view(query_layer.size()[1], query_layer.size()[0], -1), origin_key_layer.view(key_layer.size()[1], key_layer.size()[0], -1), origin_value_layer.view(value_layer.size()[1], value_layer.size()[0], -1), self.num_attention_heads, causal=True
+                        origin_query_layer.view(query_layer.size()[0], query_layer.size()[1], -1).transpose(0, 1), origin_key_layer.view(key_layer.size()[0], key_layer.size()[1], -1).transpose(0, 1), origin_value_layer.view(value_layer.size()[0], value_layer.size()[1], -1).transpose(0, 1), self.num_attention_heads, causal=True
                 ).transpose(0, 1)
         else:
             # ===================================


### PR DESCRIPTION
fmha支持的input形状是 [batch_size, seq_length, hidden_size] ，经俊丞提醒这里有个错误的用法，对于输入的q,k,v(形状是[seq_length, batch_size, hidden_size])应该是transpose而不是reshape(view)，只不过这里batch刚好是1所以不会影响输出，这个pr修复一下这个bug。