### PR TITLE
Optimize fmha style

### DIFF
--- a/codegeex/oneflow/codegeex_model.py
+++ b/codegeex/oneflow/codegeex_model.py
@@ -106,40 +106,41 @@ class SelfAttention(torch.nn.Module):
             query_layer = self.query(hidden_states)
             key_layer = self.key(hidden_states)
             value_layer = self.value(hidden_states)
-
-        if layer_past is not None:
-            past_key, past_value = layer_past
-            key_layer = torch.cat((past_key.type_as(key_layer),
-                                key_layer), dim=0)
-            value_layer = torch.cat((past_value.type_as(value_layer),
-                                    value_layer), dim=0)
-        if get_key_value:
-            present = (key_layer, value_layer)
         
-        if hasattr(torch._C, 'fused_multi_head_attention_inference_v2'):
-            if layer_past is not None:
-                context_layer = torch._C.fused_multi_head_attention_inference_v2(
-                        query=query_layer, 
-                        key=key_layer, 
-                        value=value_layer, 
-                        query_head_size=self.hidden_size_per_attention_head, 
-                        causal=False, 
-                        query_layout="MB(HK)",
-                        key_layout="MB(HK)",
-                        value_layout="MB(HK)",
-                ).transpose(0, 1)
+        fallback = not hasattr(torch._C, 'fused_multi_head_attention_inference_v2')
+
+        if fallback:
+            if hasattr(torch._C, 'fused_codegeex_qkv_reshape'):
+                query_layer, key_layer, value_layer = torch._C.fused_codegeex_qkv_reshape(query_layer, key_layer, value_layer, self.num_attention_heads)
             else:
-                context_layer = torch._C.fused_multi_head_attention_inference_v2(
-                        query=query_layer, 
-                        key=key_layer, 
-                        value=value_layer, 
-                        query_head_size=self.hidden_size_per_attention_head, 
-                        causal=True, 
-                        query_layout="MB(HK)",
-                        key_layout="MB(HK)",
-                        value_layout="MB(HK)",
-                ).transpose(0, 1)
-        else:
+                new_query_layer_shape = query_layer.size()[:-1] + \
+                                            (self.num_attention_heads,
+                                            self.hidden_size_per_attention_head)
+                query_layer = query_layer.view(*new_query_layer_shape)
+
+                new_query_layer_shape = key_layer.size()[:-1] + \
+                                        (self.num_attention_heads,
+                                        self.hidden_size_per_attention_head)
+                key_layer = key_layer.view(*new_query_layer_shape)
+
+                new_query_layer_shape = value_layer.size()[:-1] + \
+                                        (self.num_attention_heads,
+                                        self.hidden_size_per_attention_head)
+                value_layer = value_layer.view(*new_query_layer_shape)
+
+            # ==================================
+            # Adjust key and value for inference
+            # ==================================
+
+            if layer_past is not None:
+                past_key, past_value = layer_past
+                key_layer = torch.cat((past_key.type_as(key_layer),
+                                    key_layer), dim=0)
+                value_layer = torch.cat((past_value.type_as(value_layer),
+                                        value_layer), dim=0)
+            if get_key_value:
+                present = (key_layer, value_layer)
+
             # ===================================
             # Raw attention scores. [b, np, sq, sk]
             # ===================================
@@ -151,8 +152,8 @@ class SelfAttention(torch.nn.Module):
                         key_layer.size(0))
 
             # [sq, b, np, hn] -> [sq, b * np, hn]
-            query_layer = query_layer.contiguous().view(output_size[2], output_size[0] * output_size[1], -1)
-            key_layer = key_layer.contiguous().view(output_size[3], output_size[0] * output_size[1], -1)
+            query_layer = query_layer.view(output_size[2], output_size[0] * output_size[1], -1)
+            key_layer = key_layer.view(output_size[3], output_size[0] * output_size[1], -1)
 
             # Raw attention scores. [b * np, sq, sk]
             matmul_result = torch.matmul(query_layer.transpose(0, 1),
@@ -183,11 +184,22 @@ class SelfAttention(torch.nn.Module):
                     attention_mask = torch.clone(attention_mask)
                     attention_mask[:, :, context_length:, :] = True
                 
-            attention_scores = attention_scores - attention_mask * 10000.0
-            if self.attention_softmax_in_fp32:
-                attention_probs = self.softmax(attention_scores.float()).half()
+                attention_mask = ~attention_mask
+                attention_mask = attention_mask
+
+            # attention scores and attention mask [b, np, sq, sk]
+            # attention_scores = attention_mask_func(attention_scores, attention_mask)
+            if hasattr(torch._C, 'fused_scale_mask_softmax'):
+                if self.attention_softmax_in_fp32:
+                    attention_probs = torch._C.fused_scale_mask_softmax(attention_scores.float(), attention_mask, fill_value=-10000.0, scale=1.0).half()
+                else:
+                    attention_probs = torch._C.fused_scale_mask_softmax(attention_scores, attention_mask, fill_value=-10000.0, scale=1.0)
             else:
-                attention_probs = self.softmax(attention_scores)
+                attention_scores = attention_scores - attention_mask * 10000.0
+                if self.attention_softmax_in_fp32:
+                    attention_probs = self.softmax(attention_scores.float()).half()
+                else:
+                    attention_probs = self.softmax(attention_scores)
 
             # =========================
             # Context layer. [sq, b, hp]
@@ -215,16 +227,48 @@ class SelfAttention(torch.nn.Module):
             context_layer = context_layer.view(*output_size)
 
             # # [b, np, sq, hn] --> [sq, b, np, hn]
-            context_layer = context_layer.permute(2, 0, 1, 3).contiguous()
+            context_layer = context_layer.permute(2, 0, 1, 3)
 
             # # [sq, b, np, hn] --> [sq, b, hp]
             new_context_layer_shape = context_layer.size()[:-2] + \
                                     (self.hidden_size,)
             context_layer = context_layer.view(*new_context_layer_shape)
+        else:
+            if layer_past is not None:
+                past_key, past_value = layer_past
+                key_layer = torch.cat((past_key.type_as(key_layer),
+                                    key_layer), dim=0)
+                value_layer = torch.cat((past_value.type_as(value_layer),
+                                        value_layer), dim=0)
+            if get_key_value:
+                present = (key_layer, value_layer)
+            
+            if layer_past is not None:
+                context_layer = torch._C.fused_multi_head_attention_inference_v2(
+                        query=query_layer, 
+                        key=key_layer, 
+                        value=value_layer, 
+                        query_head_size=self.hidden_size_per_attention_head, 
+                        causal=False, 
+                        query_layout="MB(HK)",
+                        key_layout="MB(HK)",
+                        value_layout="MB(HK)",
+                ).transpose(0, 1)
+            else:
+                context_layer = torch._C.fused_multi_head_attention_inference_v2(
+                        query=query_layer, 
+                        key=key_layer, 
+                        value=value_layer, 
+                        query_head_size=self.hidden_size_per_attention_head, 
+                        causal=True, 
+                        query_layout="MB(HK)",
+                        key_layout="MB(HK)",
+                        value_layout="MB(HK)",
+                ).transpose(0, 1)
 
-            # =================
-            # Output. [sq, b, h]
-            # =================
+        # =================
+        # Output. [sq, b, h]
+        # =================
 
         output = self.dense(context_layer)
 
@@ -287,40 +331,41 @@ class TopQuerySelfAttention(torch.nn.Module):
             query_layer = self.query(query_hidden_state)
             key_layer = self.key(hidden_states)
             value_layer = self.value(hidden_states)
+        
+        fallback = not hasattr(torch._C, 'fused_multi_head_attention_inference_v2')
 
-        if layer_past is not None:
-            past_key, past_value = layer_past
-            key_layer = torch.cat((past_key.type_as(key_layer),
-                                   key_layer), dim=0)
-            value_layer = torch.cat((past_value.type_as(value_layer),
-                                     value_layer), dim=0)
-        if get_key_value:
-            present = (key_layer, value_layer)
-
-        if hasattr(torch._C, 'fused_multi_head_attention_inference_v2'):
-            if layer_past is not None:
-                context_layer = torch._C.fused_multi_head_attention_inference_v2(
-                        query=query_layer, 
-                        key=key_layer, 
-                        value=value_layer, 
-                        query_head_size=self.hidden_size_per_attention_head, 
-                        causal=False, 
-                        query_layout="MB(HK)",
-                        key_layout="MB(HK)",
-                        value_layout="MB(HK)",
-                ).transpose(0, 1)
+        if fallback:
+            if hasattr(torch._C, 'fused_codegeex_qkv_reshape'):
+                query_layer, key_layer, value_layer = torch._C.fused_codegeex_qkv_reshape(query_layer, key_layer, value_layer, self.num_attention_heads)
             else:
-                context_layer = torch._C.fused_multi_head_attention_inference_v2(
-                        query=query_layer, 
-                        key=key_layer, 
-                        value=value_layer, 
-                        query_head_size=self.hidden_size_per_attention_head, 
-                        causal=True, 
-                        query_layout="MB(HK)",
-                        key_layout="MB(HK)",
-                        value_layout="MB(HK)",
-                ).transpose(0, 1)
-        else:
+                new_query_layer_shape = query_layer.size()[:-1] + \
+                                        (self.num_attention_heads,
+                                        self.hidden_size_per_attention_head)
+                query_layer = query_layer.view(*new_query_layer_shape)
+
+                new_query_layer_shape = key_layer.size()[:-1] + \
+                                        (self.num_attention_heads,
+                                        self.hidden_size_per_attention_head)
+                key_layer = key_layer.view(*new_query_layer_shape)
+
+                new_query_layer_shape = value_layer.size()[:-1] + \
+                                        (self.num_attention_heads,
+                                        self.hidden_size_per_attention_head)
+                value_layer = value_layer.view(*new_query_layer_shape)
+
+            # ==================================
+            # Adjust key and value for inference
+            # ==================================
+
+            if layer_past is not None:
+                past_key, past_value = layer_past
+                key_layer = torch.cat((past_key.type_as(key_layer),
+                                    key_layer), dim=0)
+                value_layer = torch.cat((past_value.type_as(value_layer),
+                                        value_layer), dim=0)
+            if get_key_value:
+                present = (key_layer, value_layer)
+
             # ===================================
             # Raw attention scores. [b, np, sq, sk]
             # ===================================
@@ -332,12 +377,12 @@ class TopQuerySelfAttention(torch.nn.Module):
                         key_layer.size(0))
 
             # [s, b, np, hn] -> [s, b * np, hn]
-            query_layer = query_layer.contiguous().view(output_size[2], output_size[0] * output_size[1], -1)
-            key_layer = key_layer.contiguous().view(output_size[3], output_size[0] * output_size[1], -1)
+            query_layer = query_layer.view(output_size[2], output_size[0] * output_size[1], -1)
+            key_layer = key_layer.view(output_size[3], output_size[0] * output_size[1], -1)
 
             # Raw attention scores. [b * np, sq, sk]
             matmul_result = torch.matmul(query_layer.transpose(0, 1),
-                                        key_layer.transpose(0, 1).transpose(1, 2)) / self.norm_factor
+                                        key_layer.permute(1, 2, 0)) / self.norm_factor
 
             # change view to [b, np, s, s]
             attention_scores = matmul_result.view(*output_size)
@@ -399,22 +444,56 @@ class TopQuerySelfAttention(torch.nn.Module):
                                                 output_size[2], -1)
 
             # matmul: [b * np, sq, hn]
-            context_layer = torch.bmm(attention_probs, value_layer.unsqueeze(0).transpose(1, 2).squeeze(0))
+            context_layer = torch.bmm(attention_probs, value_layer.transpose(0, 1))
 
             # change view [b, np, sq, hn]
             context_layer = context_layer.view(*output_size)
 
             # [b, np, sq, hn] --> [sq, b, np, hn]
-            context_layer = context_layer.permute(2, 0, 1, 3).contiguous()
+            context_layer = context_layer.permute(2, 0, 1, 3)
 
             # [sq, b, np, hn] --> [sq, b, hp]
             new_context_layer_shape = context_layer.size()[:-2] + \
                                     (self.hidden_size,)
             context_layer = context_layer.view(*new_context_layer_shape)
 
-            # =================
-            # Output. [sq, b, h]
-            # =================
+        else:
+            if layer_past is not None:
+                past_key, past_value = layer_past
+                key_layer = torch.cat((past_key.type_as(key_layer),
+                                    key_layer), dim=0)
+                value_layer = torch.cat((past_value.type_as(value_layer),
+                                        value_layer), dim=0)
+            if get_key_value:
+                present = (key_layer, value_layer)
+
+            if hasattr(torch._C, 'fused_multi_head_attention_inference_v2'):
+                if layer_past is not None:
+                    context_layer = torch._C.fused_multi_head_attention_inference_v2(
+                            query=query_layer, 
+                            key=key_layer, 
+                            value=value_layer, 
+                            query_head_size=self.hidden_size_per_attention_head, 
+                            causal=False, 
+                            query_layout="MB(HK)",
+                            key_layout="MB(HK)",
+                            value_layout="MB(HK)",
+                    ).transpose(0, 1)
+                else:
+                    context_layer = torch._C.fused_multi_head_attention_inference_v2(
+                            query=query_layer, 
+                            key=key_layer, 
+                            value=value_layer, 
+                            query_head_size=self.hidden_size_per_attention_head, 
+                            causal=True, 
+                            query_layout="MB(HK)",
+                            key_layout="MB(HK)",
+                            value_layout="MB(HK)",
+                    ).transpose(0, 1)
+
+        # =================
+        # Output. [sq, b, h]
+        # =================
 
         output = self.dense(context_layer)
 

--- a/codegeex/oneflow/codegeex_model.py
+++ b/codegeex/oneflow/codegeex_model.py
@@ -114,8 +114,8 @@ class SelfAttention(torch.nn.Module):
                 query_layer, key_layer, value_layer = torch._C.fused_codegeex_qkv_reshape(query_layer, key_layer, value_layer, self.num_attention_heads)
             else:
                 new_query_layer_shape = query_layer.size()[:-1] + \
-                                            (self.num_attention_heads,
-                                            self.hidden_size_per_attention_head)
+                                        (self.num_attention_heads,
+                                        self.hidden_size_per_attention_head)
                 query_layer = query_layer.view(*new_query_layer_shape)
 
                 new_query_layer_shape = key_layer.size()[:-1] + \
@@ -152,12 +152,12 @@ class SelfAttention(torch.nn.Module):
                         key_layer.size(0))
 
             # [sq, b, np, hn] -> [sq, b * np, hn]
-            query_layer = query_layer.view(output_size[2], output_size[0] * output_size[1], -1)
-            key_layer = key_layer.view(output_size[3], output_size[0] * output_size[1], -1)
+            query_layer = query_layer.contiguous().view(output_size[2], output_size[0] * output_size[1], -1)
+            key_layer = key_layer.contiguous().view(output_size[3], output_size[0] * output_size[1], -1)
 
             # Raw attention scores. [b * np, sq, sk]
             matmul_result = torch.matmul(query_layer.transpose(0, 1),
-                                        key_layer.permute(1, 2, 0)) / self.norm_factor
+                                        key_layer.transpose(0, 1).transpose(1, 2)) / self.norm_factor
 
             # change view to [b, np, sq, sk]
             attention_scores = matmul_result.view(*output_size)
@@ -185,7 +185,7 @@ class SelfAttention(torch.nn.Module):
                     attention_mask[:, :, context_length:, :] = True
                 
                 attention_mask = ~attention_mask
-                attention_mask = attention_mask
+                attention_mask = attention_mask.contiguous()
 
             # attention scores and attention mask [b, np, sq, sk]
             # attention_scores = attention_mask_func(attention_scores, attention_mask)
@@ -221,13 +221,13 @@ class SelfAttention(torch.nn.Module):
             attention_probs = attention_probs.view(output_size[0] * output_size[1],
                                                 output_size[2], -1)
 
-            context_layer = torch.bmm(attention_probs, value_layer.transpose(0, 1))
+            context_layer = torch.bmm(attention_probs, value_layer.unsqueeze(0).transpose(1, 2).squeeze(0))
 
             # change view [b, np, sq, hn]
             context_layer = context_layer.view(*output_size)
 
             # # [b, np, sq, hn] --> [sq, b, np, hn]
-            context_layer = context_layer.permute(2, 0, 1, 3)
+            context_layer = context_layer.permute(2, 0, 1, 3).contiguous()
 
             # # [sq, b, np, hn] --> [sq, b, hp]
             new_context_layer_shape = context_layer.size()[:-2] + \
@@ -243,28 +243,19 @@ class SelfAttention(torch.nn.Module):
             if get_key_value:
                 present = (key_layer, value_layer)
             
-            if layer_past is not None:
-                context_layer = torch._C.fused_multi_head_attention_inference_v2(
-                        query=query_layer, 
-                        key=key_layer, 
-                        value=value_layer, 
-                        query_head_size=self.hidden_size_per_attention_head, 
-                        causal=False, 
-                        query_layout="MB(HK)",
-                        key_layout="MB(HK)",
-                        value_layout="MB(HK)",
-                ).transpose(0, 1)
-            else:
-                context_layer = torch._C.fused_multi_head_attention_inference_v2(
+            context_layer = torch._C.fused_multi_head_attention_inference_v2(
                         query=query_layer, 
                         key=key_layer, 
                         value=value_layer, 
                         query_head_size=self.hidden_size_per_attention_head, 
                         causal=True, 
+                        causal_diagonal_offset=key_layer.shape[0]-query_layer.shape[0],
                         query_layout="MB(HK)",
                         key_layout="MB(HK)",
                         value_layout="MB(HK)",
-                ).transpose(0, 1)
+                        output_layout="MB(HK)",
+                )
+
 
         # =================
         # Output. [sq, b, h]
@@ -377,12 +368,12 @@ class TopQuerySelfAttention(torch.nn.Module):
                         key_layer.size(0))
 
             # [s, b, np, hn] -> [s, b * np, hn]
-            query_layer = query_layer.view(output_size[2], output_size[0] * output_size[1], -1)
-            key_layer = key_layer.view(output_size[3], output_size[0] * output_size[1], -1)
+            query_layer = query_layer.contiguous().view(output_size[2], output_size[0] * output_size[1], -1)
+            key_layer = key_layer.contiguous().view(output_size[3], output_size[0] * output_size[1], -1)
 
             # Raw attention scores. [b * np, sq, sk]
             matmul_result = torch.matmul(query_layer.transpose(0, 1),
-                                        key_layer.permute(1, 2, 0)) / self.norm_factor
+                                        key_layer.transpose(0, 1).transpose(1, 2)) / self.norm_factor
 
             # change view to [b, np, s, s]
             attention_scores = matmul_result.view(*output_size)
@@ -410,18 +401,11 @@ class TopQuerySelfAttention(torch.nn.Module):
 
             # attention scores and attention mask [b, np, sq, sk]
             # attention_scores = attention_mask_func(attention_scores, attention_mask)
-            if hasattr(torch._C, 'fused_scale_mask_softmax'):
-                attention_mask = ~attention_mask
-                if self.attention_softmax_in_fp32:
-                    attention_probs = torch._C.fused_scale_mask_softmax(attention_scores.float(), attention_mask, fill_value=-10000.0, scale=1.0).half()
-                else:
-                    attention_probs = torch._C.fused_scale_mask_softmax(attention_scores, attention_mask, fill_value=-10000.0, scale=1.0)
+            attention_scores = attention_scores - attention_mask * 10000.0
+            if self.attention_softmax_in_fp32:
+                attention_probs = self.softmax(attention_scores.float()).half()
             else:
-                attention_scores = attention_scores - attention_mask * 10000.0
-                if self.attention_softmax_in_fp32:
-                    attention_probs = self.softmax(attention_scores.float()).half()
-                else:
-                    attention_probs = self.softmax(attention_scores)
+                attention_probs = self.softmax(attention_scores)
                 
             # =========================
             # Context layer. [sq, b, hp]
@@ -444,13 +428,13 @@ class TopQuerySelfAttention(torch.nn.Module):
                                                 output_size[2], -1)
 
             # matmul: [b * np, sq, hn]
-            context_layer = torch.bmm(attention_probs, value_layer.transpose(0, 1))
+            context_layer = torch.bmm(attention_probs, value_layer.unsqueeze(0).transpose(1, 2).squeeze(0))
 
             # change view [b, np, sq, hn]
             context_layer = context_layer.view(*output_size)
 
             # [b, np, sq, hn] --> [sq, b, np, hn]
-            context_layer = context_layer.permute(2, 0, 1, 3)
+            context_layer = context_layer.permute(2, 0, 1, 3).contiguous()
 
             # [sq, b, np, hn] --> [sq, b, hp]
             new_context_layer_shape = context_layer.size()[:-2] + \
@@ -468,28 +452,18 @@ class TopQuerySelfAttention(torch.nn.Module):
                 present = (key_layer, value_layer)
 
             if hasattr(torch._C, 'fused_multi_head_attention_inference_v2'):
-                if layer_past is not None:
-                    context_layer = torch._C.fused_multi_head_attention_inference_v2(
-                            query=query_layer, 
-                            key=key_layer, 
-                            value=value_layer, 
-                            query_head_size=self.hidden_size_per_attention_head, 
-                            causal=False, 
-                            query_layout="MB(HK)",
-                            key_layout="MB(HK)",
-                            value_layout="MB(HK)",
-                    ).transpose(0, 1)
-                else:
-                    context_layer = torch._C.fused_multi_head_attention_inference_v2(
-                            query=query_layer, 
-                            key=key_layer, 
-                            value=value_layer, 
-                            query_head_size=self.hidden_size_per_attention_head, 
-                            causal=True, 
-                            query_layout="MB(HK)",
-                            key_layout="MB(HK)",
-                            value_layout="MB(HK)",
-                    ).transpose(0, 1)
+                context_layer = torch._C.fused_multi_head_attention_inference_v2(
+                        query=query_layer, 
+                        key=key_layer, 
+                        value=value_layer, 
+                        query_head_size=self.hidden_size_per_attention_head, 
+                        causal=True, 
+                        causal_diagonal_offset=key_layer.shape[0]-query_layer.shape[0],
+                        query_layout="MB(HK)",
+                        key_layout="MB(HK)",
+                        value_layout="MB(HK)",
+                        output_layout="MB(HK)",
+                )
 
         # =================
         # Output. [sq, b, h]

--- a/codegeex/quantization/quantize_oneflow.py
+++ b/codegeex/quantization/quantize_oneflow.py
@@ -68,7 +68,7 @@ class QuantizedLinear(torch.nn.Module):
         self.weight_bit_width = weight_bit_width
         self.symmetric = True
         self.group_dim = 1
-        self.group_size = in_features // 64
+        self.group_size = in_features
 
         self.weight, self.weight_scale, self.weight_zero = _quantize(
             self.weight_bit_width, self.symmetric, weight, self.group_dim, self.group_size, torch.int8


### PR DESCRIPTION
- [x] 整理不使用 fused_multi_head_attention_inference_v2 时的原始代码，保证在fused_multi_head_attention_inference_v2无法生效时fallback的代码可以成功执行。
- [x] fused_multi_head_attention_inference_v2 用法更新，设置output_layout避免手动transpose batch和seq维度，使用causal_diagonal_offset代替对layer_past的特判，代码更加干净。
- [x] quantize_oneflow部分修复bug，把self.group_size从in_features//64改为in_features，seq_length为1024时速度从21.93->17.57s。
- [x] 针对是否fallback以及fp16/int8都进行了测试，可以正确的跑出结果。 