### PR TITLE
attention linear support quantization

### DIFF
--- a/codegeex/oneflow/codegeex_model.py
+++ b/codegeex/oneflow/codegeex_model.py
@@ -2,7 +2,7 @@ import math
 import oneflow as torch
 import oneflow.nn.functional as F
 from oneflow.nn.parameter import Parameter
-
+from ..quantization import QuantizedLinear
 
 def fast_gelu(x):
     """Mindspore's fast gelu implementation."""
@@ -98,7 +98,7 @@ class SelfAttention(torch.nn.Module):
         # Query, Key, and Value
         # =====================
 
-        if hasattr(torch._C, 'grouped_matmul_bias'):
+        if hasattr(torch._C, 'grouped_matmul_bias') and not isinstance(self.query, QuantizedLinear):
             query_layer, key_layer, value_layer = torch._C.grouped_matmul_bias([hidden_states, hidden_states, hidden_states], 
                                                                                 [self.query.weight, self.key.weight, self.value.weight],
                                                                                 [self.query.bias, self.key.bias, self.value.bias])
@@ -314,7 +314,7 @@ class TopQuerySelfAttention(torch.nn.Module):
     ):
 
         # hidden_states: [sq, b, h]
-        if hasattr(torch._C, 'grouped_matmul_bias'):
+        if hasattr(torch._C, 'grouped_matmul_bias') and not isinstance(self.query, QuantizedLinear):
             query_layer, key_layer, value_layer = torch._C.grouped_matmul_bias([query_hidden_state, hidden_states, hidden_states], 
                                                                                 [self.query.weight, self.key.weight, self.value.weight],
                                                                                 [self.query.bias, self.key.bias, self.value.bias])

--- a/codegeex/quantization/__init__.py
+++ b/codegeex/quantization/__init__.py
@@ -1,2 +1,3 @@
 from .quantize import quantize
 from .quantize_oneflow import quantize_oneflow
+from .quantize_oneflow import QuantizedLinear

--- a/codegeex/quantization/quantize_oneflow.py
+++ b/codegeex/quantization/quantize_oneflow.py
@@ -109,6 +109,42 @@ def quantize_oneflow(model, weight_bit_width):
         else:
             layer = model.language_model.transformer.layers[i]
         
+        layer.attention.query = QuantizedLinear(
+            in_features=layer.attention.query.in_features,
+            out_features=layer.attention.query.out_features,
+            weight_bit_width=weight_bit_width,
+            weight=layer.attention.query.weight.to(torch.cuda.current_device()),
+            bias=layer.attention.query.bias.to(torch.cuda.current_device()),
+            params_dtype=torch.half,
+            device=layer.attention.query.weight.device,
+        )
+        layer.attention.value = QuantizedLinear(
+            in_features=layer.attention.value.in_features,
+            out_features=layer.attention.value.out_features,
+            weight_bit_width=weight_bit_width,
+            weight=layer.attention.value.weight.to(torch.cuda.current_device()),
+            bias=layer.attention.value.bias.to(torch.cuda.current_device()),
+            params_dtype=torch.half,
+            device=layer.attention.value.weight.device,
+        )
+        layer.attention.key = QuantizedLinear(
+            in_features=layer.attention.key.in_features,
+            out_features=layer.attention.key.out_features,
+            weight_bit_width=weight_bit_width,
+            weight=layer.attention.key.weight.to(torch.cuda.current_device()),
+            bias=layer.attention.key.bias.to(torch.cuda.current_device()),
+            params_dtype=torch.half,
+            device=layer.attention.key.weight.device,
+        )
+        layer.attention.dense = QuantizedLinear(
+            in_features=layer.attention.dense.in_features,
+            out_features=layer.attention.dense.out_features,
+            weight_bit_width=weight_bit_width,
+            weight=layer.attention.dense.weight.to(torch.cuda.current_device()),
+            bias=layer.attention.dense.bias.to(torch.cuda.current_device()),
+            params_dtype=torch.half,
+            device=layer.attention.dense.weight.device,
+        )
         layer.mlp.dense_h_to_4h = QuantizedLinear(
             in_features=layer.mlp.dense_h_to_4h.in_features,
             out_features=layer.mlp.dense_h_to_4h.out_features,
@@ -127,5 +163,6 @@ def quantize_oneflow(model, weight_bit_width):
             params_dtype=torch.half,
             device=layer.mlp.dense_4h_to_h.weight.device,
         )
+        
         
     return model


### PR DESCRIPTION
-[x] attention部分的q,k,v以及output的4个linear支持int8量化，序列长度为1024时速度从7.57->14.64，现在应该已经比FasterTransformer的int8推理要快了。