### PR TITLE
add ONEFLOW_LINEAR_EMBEDDING_SKIP_INIT

### DIFF
--- a/tests/test_inference_oneflow.py
+++ b/tests/test_inference_oneflow.py
@@ -12,6 +12,7 @@ from codegeex.oneflow import CodeGeeXModel
 from codegeex.tokenizer import CodeGeeXTokenizer
 from codegeex.quantization import quantize_oneflow
 os.environ["ONEFLOW_KERNEL_ENABLE_FUSED_LINEAR"] = "1"
+os.environ["ONEFLOW_LINEAR_EMBEDDING_SKIP_INIT"] = "1"
 
 def model_provider(args):
     """Build the model."""


### PR DESCRIPTION
模型初始化和加载时间从大约3分钟降低到10s左右。